### PR TITLE
feat: 접수완료 페이지에 마라톤명과 코스 타입 표시 (#16)

### DIFF
--- a/app/marathons/[id]/courses/[courseId]/register/complete/page.tsx
+++ b/app/marathons/[id]/courses/[courseId]/register/complete/page.tsx
@@ -11,7 +11,9 @@ import { Separator } from '@/components/ui/separator'
 interface RegistrationData {
   registrationId: number
   marathonId: number
+  marathonTitle: string
   courseId: number
+  courseType: string
   status: string
   appliedAt: string
 }
@@ -20,7 +22,6 @@ export default function CompletePage() {
   const params = useParams()
   const router = useRouter()
   const marathonId = parseInt(params.id as string)
-  const courseId = parseInt(params.courseId as string)
 
   const [registration, setRegistration] = useState<RegistrationData | null>(null)
   const [isLoading, setIsLoading] = useState(true)
@@ -119,12 +120,12 @@ export default function CompletePage() {
 
             <div className="grid grid-cols-2 gap-4">
               <div>
-                <p className="text-sm text-muted-foreground mb-1">대회 ID</p>
-                <p className="font-medium text-foreground">{registration.marathonId}</p>
+                <p className="text-sm text-muted-foreground mb-1">마라톤명</p>
+                <p className="font-medium text-foreground">{registration.marathonTitle}</p>
               </div>
               <div>
-                <p className="text-sm text-muted-foreground mb-1">코스 ID</p>
-                <p className="font-medium text-foreground">{registration.courseId}</p>
+                <p className="text-sm text-muted-foreground mb-1">코스 타입</p>
+                <p className="font-medium text-foreground">{registration.courseType}</p>
               </div>
             </div>
 
@@ -181,7 +182,7 @@ export default function CompletePage() {
             variant="outline"
             className="flex-1"
             onClick={() => {
-              const content = `접수 번호: #${registration.registrationId}\n상태: ${statusBadge.label}\n접수 일시: ${formatDate(registration.appliedAt)}`
+              const content = `접수 번호: #${registration.registrationId}\n마라톤명: ${registration.marathonTitle}\n코스 타입: ${registration.courseType}\n상태: ${statusBadge.label}\n접수 일시: ${formatDate(registration.appliedAt)}`
               navigator.clipboard.writeText(content)
             }}
           >

--- a/components/registration-form.tsx
+++ b/components/registration-form.tsx
@@ -107,7 +107,9 @@ export function RegistrationForm({ courseId, courseName, marathonTitle }: Regist
       const registrationData = {
         registrationId: data.data.registrationId,
         marathonId: data.data.marathonId,
+        marathonTitle: data.data.marathonTitle,
         courseId: data.data.courseId,
+        courseType: data.data.courseType,
         status: data.data.status,
         appliedAt: data.data.appliedAt,
       }

--- a/lib/registration.ts
+++ b/lib/registration.ts
@@ -1,33 +1,35 @@
 export interface CreateRegistrationReq {
-    marathonId: number
-    courseId: number
+  marathonId: number
+  courseId: number
+}
+
+export interface CreateRegistrationRes {
+  registrationId: number
+  marathonId: number
+  marathonTitle: string
+  courseId: number
+  courseType: string
+  status: string
+  appliedAt: string
+}
+
+export async function createRegistration(
+  body: CreateRegistrationReq
+): Promise<CreateRegistrationRes> {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/registrations`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+    body: JSON.stringify(body),
+  })
+
+  const data = await res.json()
+
+  if (!res.ok) {
+    throw new Error(data.message || "접수 실패")
   }
-  
-  export interface CreateRegistrationRes {
-    registrationId: number
-    marathonId: number
-    courseId: number
-    status: string
-    appliedAt: string
-  }
-  
-  export async function createRegistration(
-    body: CreateRegistrationReq
-  ): Promise<CreateRegistrationRes> {
-    const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/registrations`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      credentials: "include",
-      body: JSON.stringify(body),
-    })
-  
-    const data = await res.json()
-  
-    if (!res.ok) {
-      throw new Error(data.message || "접수 실패")
-    }
-  
-    return data.data
-  }
+
+  return data.data
+}


### PR DESCRIPTION
## 📌 관련 이슈
Closes #16

## 🛠️ 작업 내용
- [x] 접수 성공 응답의 `marathonTitle`, `courseType`을 `lastRegistration`에 저장하도록 수정
- [x] 접수완료 페이지에서 `대회 ID`, `코스 ID` 대신 `마라톤명`, `코스 타입`을 표시하도록 변경
- [x] 접수 정보 복사 시 `마라톤명`, `코스 타입`이 함께 복사되도록 수정


## 🎯 리뷰 포인트
접수 완료 페이지 구성 변경이 적절한지 확인 부탁드립니다.


## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
변경전
<img width="887" height="862" alt="스크린샷 2026-04-21 오후 2 31 33" src="https://github.com/user-attachments/assets/fb3c9772-beaf-461e-9ae7-726fd0152211" />
변경후
<img width="834" height="860" alt="스크린샷 2026-04-21 오후 2 45 11" src="https://github.com/user-attachments/assets/7a39ead4-d705-42e6-8a1f-bb60effc0231" />

## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?