### PR TITLE
refactor: 보호 API 호출을 fetchWithAuth로 통일 (#24)

### DIFF
--- a/app/marathons/create/page.tsx
+++ b/app/marathons/create/page.tsx
@@ -9,7 +9,7 @@ import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { API_BASE_URL } from "@/lib/api-base"
+import { fetchWithAuth } from "@/lib/api-base"
 import { ArrowLeft, Plus, X, Calendar, MapPin, Users, Trophy } from "lucide-react"
 
 type Region = "SEOUL" | "GYEONGGI" | "INCHEON" | "BUSAN" | "DAEGU" | "DAEJEON" | "GWANGJU" | "ULSAN" | "SEJONG" | "GANGWON" | "CHUNGBUK" | "CHUNGNAM" | "JEONBUK" | "JEONNAM" | "GYEONGBUK" | "GYEONGNAM" | "JEJU"
@@ -171,7 +171,7 @@ export default function CreateMarathonPage() {
   
     try {
   
-      const response = await fetch(`${API_BASE_URL}/api/v1/marathons`, {
+      const response = await fetchWithAuth("/api/v1/marathons", {
   
         method: "POST",
   
@@ -180,8 +180,6 @@ export default function CreateMarathonPage() {
           "Content-Type": "application/json",
   
         },
-  
-        credentials: "include",
   
         body: JSON.stringify({
   

--- a/app/mypage/page.tsx
+++ b/app/mypage/page.tsx
@@ -17,7 +17,7 @@ import {
   CardTitle,
 } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
-import { API_BASE_URL } from "@/lib/api-base"
+import { fetchWithAuth } from "@/lib/api-base"
 
 /** GET /api/v1/users/me — 컨트롤러가 직접 반환하거나 ApiResponse로 감쌀 수 있음 */
 interface MyProfileRes {
@@ -104,9 +104,8 @@ export default function MyPage() {
     setError(null)
     setLoading(true)
     try {
-      const res = await fetch(`${API_BASE_URL}/api/v1/users/me`, {
+      const res = await fetchWithAuth("/api/v1/users/me", {
         method: "GET",
-        credentials: "include",
       })
 
       if (res.status === 401) {
@@ -172,9 +171,8 @@ export default function MyPage() {
     setSaving(true)
     setError(null)
     try {
-      const res = await fetch(`${API_BASE_URL}/api/v1/users/me`, {
+      const res = await fetchWithAuth("/api/v1/users/me", {
         method: "PATCH",
-        credentials: "include",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           name: trimmedName,

--- a/components/registration-form.tsx
+++ b/components/registration-form.tsx
@@ -10,6 +10,7 @@ import { Checkbox } from "@/components/ui/checkbox"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Separator } from "@/components/ui/separator"
+import { fetchWithAuth } from "@/lib/api-base"
 import { MapPin, Shirt, FileText, AlertCircle } from "lucide-react"
 
 type KakaoPostcodeData = {
@@ -156,12 +157,11 @@ export function RegistrationForm({ courseId, courseName, marathonTitle }: Regist
         agreedTerms: form.agreedTerms,
       }
 
-      const response = await fetch("http://localhost:8080/api/v1/registrations", {
+      const response = await fetchWithAuth("/api/v1/registrations", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
-        credentials: "include",
         body: JSON.stringify(body),
       })
 

--- a/lib/api-base.ts
+++ b/lib/api-base.ts
@@ -43,7 +43,7 @@ export async function fetchWithAuth(
 
   let response = await fetch(fullUrl, defaultOptions)
 
-  if (response.status === 401 || response.status === 403) {
+  if (response.status === 401) {
     console.warn("Access Token 만료 → 재발급 시도")
 
     const reissued = await reissueToken()

--- a/lib/api-base.ts
+++ b/lib/api-base.ts
@@ -3,7 +3,7 @@ export const API_BASE_URL = "http://localhost:8080"
 // 토큰 재발급 함수
 async function reissueToken(): Promise<boolean> {
   try {
-    const response = await fetch(`${API_BASE_URL}/auth/reissue`, {
+    const response = await fetch(`${API_BASE_URL}/api/v1/auth/reissue`, {
       method: "POST",
       credentials: "include", // 쿠키 포함
     })
@@ -26,14 +26,19 @@ export async function fetchWithAuth(
   options: RequestInit = {}
 ): Promise<Response> {
   const fullUrl = url.startsWith("http") ? url : `${API_BASE_URL}${url}`
+  const headers = new Headers(options.headers)
+  const isFormDataRequest = options.body instanceof FormData
+
+  if (isFormDataRequest) {
+    headers.delete("Content-Type")
+  } else if (!headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json")
+  }
 
   const defaultOptions: RequestInit = {
     ...options,
     credentials: "include", // 쿠키 자동 포함
-    headers: {
-      "Content-Type": "application/json",
-      ...(options.headers || {}),
-    },
+    headers,
   }
 
   let response = await fetch(fullUrl, defaultOptions)


### PR DESCRIPTION
## 📌 관련 이슈
Closes #24

## 🛠️ 작업 내용
- [x] 보호 API 호출을 상대 경로 기준으로 정리하여 공통 인증 유틸 사용 방식 통일

## 🎯 리뷰 포인트
> 리뷰 시 중점적으로 봐주었으면 하는 부분이 있다면 적어주세요.
- 리뷰 포인트


## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [ ] 로컬에서 충분히 테스트를 진행했나요?