### PR TITLE
feat: 접수현황 버튼 추가 및 헤더에 대회목록으로 변경 (#50)

### DIFF
--- a/app/marathons/myMarathons/page.tsx
+++ b/app/marathons/myMarathons/page.tsx
@@ -101,31 +101,31 @@ export default function MyMarathonsPage() {
   const checkAuth = useCallback(async () => {
     try {
       const res = await fetchWithAuth("/api/v1/users/me", { method: "GET" })
-  
+
       if (res.status === 401) {
         setAuthStatus("unauthenticated")
         return
       }
-  
+
       if (!res.ok) {
         setAuthStatus("unauthenticated")
         return
       }
-  
+
       const json: unknown = await res.json()
       let role: string | undefined
-  
+
       if (isApiEnvelope(json) && json.data) {
         role = (json.data as { role?: string }).role
       } else if (typeof json === "object" && json !== null && "role" in json) {
         role = (json as { role?: string }).role
       }
-  
+
       if (role !== "ORGANIZER" && role !== "ADMIN") {
         setAuthStatus("unauthorized")
         return
       }
-  
+
       setAuthStatus("authenticated")
     } catch {
       setAuthStatus("unauthenticated")
@@ -168,7 +168,7 @@ export default function MyMarathonsPage() {
             ? `http://localhost:8080${marathon.posterImageUrl}`
             : marathon.posterImageUrl,
       }))
-      
+
       setMarathons(normalizedData)
     } catch (e) {
       setError(e instanceof Error ? e.message : "알 수 없는 오류가 발생했습니다.")
@@ -406,6 +406,14 @@ export default function MyMarathonsPage() {
                       >
                         {marathonStatusToUi(marathon.status)}
                       </Badge>
+                      <Link
+                        href={`/organizer/marathons/${marathon.id}/registrations`}
+                        className="absolute right-3 top-10 mt-1"
+                      >
+                        <Badge className="bg-white/90 text-foreground hover:bg-white cursor-pointer shadow-sm">
+                          접수 현황
+                        </Badge>
+                      </Link>
                     </div>
                   </CardHeader>
                   <CardContent className="p-4">

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -92,7 +92,7 @@ export function Header() {
             href={myMarathonsHref}
             className="text-sm font-medium text-muted-foreground transition-colors hover:text-primary"
           >
-            대회 현황
+            대회 목록
           </Link>
         </nav>
 


### PR DESCRIPTION
## 📌 관련 이슈
> PR과 연관된 이슈 번호를 작성해주세요.  
> PR 머지 시 이슈를 닫으려면 `Closes #번호` 형식으로 작성해주세요. ex) `Closes #2`

Closes #50

## 🛠️ 작업 내용
> PR에서 작업한 주요 내용을 적어주세요.
- [x] 헤더에 `대회 현황` 버튼명을 `대회 목록`으로 변경
- [x] `접수 현황` 버튼 추가하여 `localhost:3000/organizer/marathons/[id]/registrations` 페이지로 연결


## 🎯 리뷰 포인트
> 리뷰 시 중점적으로 봐주었으면 하는 부분이 있다면 적어주세요.
- 헤더의 버튼 명을 **대회 목록**으로 바꾸었는데 괜찮은지 확인 부탁드립니다.
- `접수 현황` 버튼의 위치가 적절한지 확인 부탁드립니다. 


## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
<img width="1728" height="1041" alt="스크린샷 2026-04-22 오후 7 41 28" src="https://github.com/user-attachments/assets/85baefe5-26d4-42b4-b12e-8c084d19ac14" />

## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?