### PR TITLE
feat: 참가자용 내 접수 조회 버튼 추가 및 접수 완료 페이지 수정 (#54)

### DIFF
--- a/app/marathons/[id]/courses/[courseId]/register/complete/page.tsx
+++ b/app/marathons/[id]/courses/[courseId]/register/complete/page.tsx
@@ -190,9 +190,14 @@ export default function CompletePage() {
             접수 정보 복사
           </Button>
           <Link href={`/marathons/${marathonId}`} className="flex-1">
-            <Button className="w-full">
+            <Button variant="outline" className="w-full">
               <ArrowLeft className="mr-2 h-4 w-4" />
               대회 상세 정보 보기
+            </Button>
+          </Link>
+          <Link href="/mypage/registrations" className="flex-1">
+            <Button className="w-full">
+              내 접수 조회
             </Button>
           </Link>
         </div>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -48,14 +48,14 @@ export function Header() {
   const createHref = !isLoggedIn
     ? "/login?redirect=/marathons/create"
     : isOrganizerOrAdmin
-    ? "/marathons/create"
-    : "/marathons/create?unauthorized=true"
+      ? "/marathons/create"
+      : "/marathons/create?unauthorized=true"
 
   const myMarathonsHref = !isLoggedIn
     ? "/login?redirect=/marathons/myMarathons"
     : isOrganizerOrAdmin
-    ? "/marathons/myMarathons"
-    : "/marathons/create?unauthorized=true"
+      ? "/marathons/myMarathons"
+      : "/marathons/create?unauthorized=true"
 
   return (
     <header className="sticky top-0 z-50 w-full border-b border-border bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/60">
@@ -93,6 +93,12 @@ export function Header() {
             className="text-sm font-medium text-muted-foreground transition-colors hover:text-primary"
           >
             대회 목록
+          </Link>
+          <Link
+            href="/mypage/registrations"
+            className="text-sm font-medium text-muted-foreground transition-colors hover:text-primary"
+          >
+            내 접수 조회
           </Link>
         </nav>
 
@@ -174,6 +180,12 @@ export function Header() {
               onClick={() => setIsMobileMenuOpen(false)}
             >
               대회 현황
+            </Link>
+            <Link
+              href="/mypage/registrations"
+              className="text-sm font-medium text-muted-foreground transition-colors hover:text-primary"
+            >
+              내 접수 조회
             </Link>
             <div className="mt-2 flex flex-col gap-2 border-t border-border pt-4">
               {isLoggedIn ? (


### PR DESCRIPTION
## 📌 관련 이슈
> PR과 연관된 이슈 번호를 작성해주세요.  
> PR 머지 시 이슈를 닫으려면 `Closes #번호` 형식으로 작성해주세요. ex) `Closes #2`

Closes #54

## 🛠️ 작업 내용
> PR에서 작업한 주요 내용을 적어주세요.
- [x] 헤더에 `내 접수 조회` 버튼 추가
- [x] 접수 완료 시 `내 접수 조회` 버튼 추가하여 접수 목록으로 바로 갈 수 있도록 수정


## 🎯 리뷰 포인트
> 리뷰 시 중점적으로 봐주었으면 하는 부분이 있다면 적어주세요.
- 버튼명이 `내 접수 조회`가 적절한지 확인 부탁드립니다.


## 📸 스크린샷 (선택 - 프론트엔드 작업 시)
- 내 접수 조회 버튼 추가
<img width="1728" height="1041" alt="image" src="https://github.com/user-attachments/assets/8c53de25-24a5-4093-8d64-675ed82b7234" />

- 접수 완료 시 버튼 추가
<img width="1728" height="1041" alt="image" src="https://github.com/user-attachments/assets/c6b76093-9cf9-4add-b097-15d41ded8d8e" />


## ✅ 체크리스트
- [x] PR 제목 규칙을 잘 지켰나요? (예: `feat: 작업내용 (#이슈번호)`)
- [x] 팀의 코딩 컨벤션을 준수했나요?
- [x] 로컬에서 충분히 테스트를 진행했나요?